### PR TITLE
Fix:   missing index html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+  <link rel="stylesheet" href="css/main.css" type="text/css">
+  <link rel="icon" href="public/usedresources/favicon.png" type="image/png">
+</head>
+<body>
+  <h1>index homepage?</h1>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:eleventy": "npx @11ty/eleventy",
     "prestart": "rm -rf ./dist",
     "start": "npm-run-all prestart --parallel build:styles --parallel watch:*",
-    "build": "npm-run-all build:*",
+    "build": "npm-run-all prestart build:*",
     "lint:js": "eslint . --ext .js",
     "lint:scss": "stylelint **/*.scss",
     "lint": "run-s lint:js lint:scss",


### PR DESCRIPTION
Chrome, Edge & Safari all display the README in the root directory, instead of the base.njk & index.md page. It might be because we're missing the index.html page at the root.