### PR TITLE
Refactor: header markup & styles revamp

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -5,22 +5,29 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{title}}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Raleway:wght@400&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/main.css" type="text/css">
   <link rel="icon" href="public/usedresources/favicon.png" type="image/png">
 </head>
 
 <body>
-  <header>
-    <nav class="header-nav">
-      <a href="index.html">
+  <header class="cmp-header">
+    <nav class="cmp-header__container">
+      <a href="index.html" class="cmp-header__home-link">
         {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
       </a>
-      <ul>
-        <li><a href="work/work-examples.html">Projects</a></li>
-        <!-- <li><a href="#projects">Projects</a></li> -->
-        <!-- <li><a href="work/workexamples.html">Projects</a></li> -->
-        <li><a href="resume/resume.html">Resume</a></li>
-        <li><a href="contact/contact.html">Contact</a></li>
+      <ul class="cmp-header__link-list">
+        <li class="cmp-header__list-item">
+          <a class="cmp-header__link" href="work/work-examples.html">Projects</a>
+        </li>
+        <li class="cmp-header__list-item">
+          <a class="cmp-header__link" href="resume/resume.html">Resume</a>
+        </li>
+        <li class="cmp-header__list-item">
+          <a class="cmp-header__link" href="contact/contact.html">Contact</a>
+        </li>
       </ul>
     </nav>
   </header>
@@ -35,7 +42,7 @@
             </h2>
           </div>
 
-          <h1>{{ content | safe }}</h1>
+          {{ content | safe }}
         </div>
       </div> 
 
@@ -133,7 +140,6 @@
       <section class="collab-cta">
         <p>
           {{collabText.paragraph}} <strong>{{collabText.bold}}</strong>
-          {# Interested in working together or collaborating on a project? <strong>Shoot me a message!</strong> #}
         </p>
         <a href="contact/contact.html">{{collabText.linkText}}</a>
       </section>

--- a/src/scss/components/_header.scss
+++ b/src/scss/components/_header.scss
@@ -1,0 +1,65 @@
+@use '../general/general';
+
+.cmp-header {
+  width: 100%;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  padding: 1rem;
+  background-color: hsla(var(--color-white), 0.95);
+  box-shadow: 0 0 0.625rem hsla(var(--color-black), 0.1);
+  max-height: general.$header-height;
+  box-sizing: border-box;
+  
+  &__container {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    flex-direction: column;
+    gap: 1rem;
+    justify-content: space-between;
+
+    @media (min-width: general.$bp-medium) {
+      max-width: general.$max-page-width;
+      margin: auto;
+      flex-direction: row;
+    }
+  }
+
+  &__link-list {
+    display: flex;
+    width: 100%;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    align-items: center;
+    justify-content: space-between;
+
+    @media (min-width: general.$bp-small) {
+      justify-content: center;
+      gap: 2rem;
+    }
+
+    @media (min-width: general.$bp-medium) {
+      justify-content: flex-end;
+    }
+  }
+
+  &__link {
+    text-align: center;
+    font-weight: 600;
+    padding: 0.5em;
+    color: var(--color-bright-coral);
+    text-decoration: none;
+    transition: general.$default-transition;
+    border-radius: general.$pill-border-radius;
+
+    @media (min-width: 50rem) {
+      padding: 1rem 1.5rem;
+    }
+    
+    &:hover {
+      background-color: var(--color-light-peach-transparent);
+    }
+  }
+}

--- a/src/scss/elements/_body.scss
+++ b/src/scss/elements/_body.scss
@@ -1,0 +1,7 @@
+body {
+  font-family: "Montserrat", "Raleway", sans-serif;
+  margin:0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/scss/elements/_html.scss
+++ b/src/scss/elements/_html.scss
@@ -1,0 +1,5 @@
+html {
+  height: 100%;
+  margin:0;
+  padding: 0;
+}

--- a/src/scss/elements/_root.scss
+++ b/src/scss/elements/_root.scss
@@ -1,0 +1,10 @@
+:root {
+  --color-dark-teal: hsl(194, 65%, 28%);
+  --color-light-peach: hsl(0, 100%, 98%);
+  --color-light-peach-transparent: hsla(0, 100%, 98%, 0.8);
+  --color-bright-coral: hsl(11, 88%, 62%);
+  --color-bright-coral-transparent: hsla(11, 88%, 62%, 0.08);
+  // black & white are used a lot with an alpha value in hsla
+  --color-white: 0, 100%, 100%;
+  --color-black: 0, 0%, 0%;
+}

--- a/src/scss/general/_general.scss
+++ b/src/scss/general/_general.scss
@@ -1,0 +1,11 @@
+// TODO: small vs. large screen padding
+$max-page-width: 75rem;
+
+$bp-small: 30rem;
+$bp-medium: 50rem;
+
+$header-height: 8rem;
+
+$pill-border-radius: 3rem;
+
+$default-transition: all ease-in-out 0.2s;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,94 +1,36 @@
-/* rgba(243, 103, 72, 0.08)
-#F36748
+// SETTINGS
 
-maybe for the rest of the portfolio?
-#4281a4;
-004f4a */
+// TOOLS
 
-@use './components/blog-page';
-@use './components/contact-page';
-@use './components/resume-page';
-@use './components/work-examples-page';
-@use './components/neverland-travelers-page';
-@use './components/financial-page';
-@use './components/iceland-page';
+// GENERAL
+@forward './general/general';
 
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300;400;500;600;700;900&family=Raleway:wght@100;300;400&display=swap');
+// ELEMENTS
+@forward './elements/html';
+@forward './elements/body';
+@forward './elements/root';
 
-* {
-    box-sizing: border-box;
-    margin:0;
-    padding: 0;
-    font-family: "Montserrat", "Raleway", sans-serif;
-}
+// OBJECTS/LAYOUTS
 
-html {
-    height: 100%;
-}
+// COMPONENTS
+@forward './components/header';
+@forward './components/blog-page';
+@forward './components/contact-page';
+@forward './components/resume-page';
+@forward './components/work-examples-page';
+@forward './components/neverland-travelers-page';
+@forward './components/financial-page';
+@forward './components/iceland-page';
 
-body {
-    position: relative;
-    // height: 100vh;
-    display: flex;
-    flex-direction: column;
-}
+// VENDOR
 
-header {
-    width: 100%;
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    padding-left: 7.5%;
-    padding-right: 7.5%;
-    background-color: rgba(255, 255, 255, 0.95);
-    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
-    max-height: 5rem;
-}
+// UTILITIES
 
-.header-nav {
-    margin: 0;
-    padding: 0;
-    /* border: 1px solid red; */
-    display: flex;
-    flex-basis: 100%;
-    align-items: center;
-    justify-content: space-between;
-}
 
-.header-nav ul {
-   display: flex;
-   flex-basis: 40%;
-   list-style-type: none;
-   align-items: center;
-   justify-content: space-between;
-   /* border: 1px solid red; */
-}
-
-.header-nav a img {
-    /* border: 1px solid purple; */
-    padding: 10%;
-}
-
-.header-nav ul a {
-    /* border: 1px solid blue; */
-    /* line-height: 4rem; */
-    width: 50%;
-    text-align: center;
-    font-weight: 600;
-    padding: 1em 1.5em;
-    color: #F36748;
-    text-decoration: none;
-    transition: all ease-in-out 0.2s;
-}
-
-.header-nav ul a:hover {
-    background-color: rgba(243, 103, 72, 0.08);
-    border-radius: 50px;
-}
 
 .body-container {
     padding: 0;
-    background-color: #196076;
+    background-color: var(--color-dark-teal);
     height: 100%;
 }
 
@@ -584,10 +526,6 @@ footer p {
 /* responsive/mobile */
 
 @media only screen and (max-width: 1220px) {
-    .header-nav ul {
-        flex-basis: 60%;
-        /* border: 1px solid red; */
-     }
 
     .hero-section h2 span {
         /* border: 1px solid red; */
@@ -632,10 +570,6 @@ footer p {
 }
 
 @media only screen and (max-width: 900px) {
-    .header-nav ul {
-        flex-basis: 80%;
-        /* border: 1px solid red; */
-     }
 
      .hero-section h2 span {
         /* border: 1px solid red; */
@@ -657,10 +591,6 @@ footer p {
 
 
 @media only screen and (max-width: 768px) {
-    .header-nav ul a:active {
-        background-color: rgba(243, 103, 72, 0.16);
-
-    }
 
     .hero-section h2 span {
         /* border: 1px solid red; */
@@ -771,28 +701,6 @@ footer p {
 
 
 @media only screen and (max-width: 500px) {
-    header {
-        padding: 0;
-    }
-    
-    .header-nav {
-        /* border: 1px solid red; */
-        display: flex;
-        flex-direction: column;
-        flex-basis: 100%;
-    }
-
-    .header-nav a img {
-        /* border: 1px solid purple; */
-        display: block;        
-        margin: auto;
-    }
-
-    .header-nav ul {
-        /* border: 1px solid red; */
-        width: 100%;
-        padding-bottom: 5%;
-    }
     
     .hero-section h2 span {
         /* border: 1px solid red; */
@@ -868,9 +776,6 @@ footer p {
 }
 
 @media only screen and (max-width: 325px) {
-    .header-nav ul a {
-        padding: 4%;
-    }
     
     .hero-section h2 span {
         /* border: 1px solid red; */


### PR DESCRIPTION
Refactors the `header` with BEM markup, and extracts any header styles into SCSS partials (removing those styles from `main.scss`:

- uses BEM naming convention for classes in base.njk
- creates header-nav.scss for header/navigation styles
- extracts html/body styles into elements.scss
- creates CSS custom properties in root.scss
- creates SCSS variables general.scss
- imports new scss partials into main.scss

This should be almost an exact parity of the current site design.

![Home](https://github.com/marissahuysentruyt/marissahuysentruyt/assets/69602589/ec2fc643-ce5a-4b89-87cd-6c89a03d20d1)

### Validation
- [ ] Pull down the branch
- [ ] Run `npm install`, then `npm start`
- [ ] In your editor, find the `src/scss` directory. You should see new SCSS partials created, along with a `main.scss` file
- [ ] The `main.scss` fille still has vanilla CSS included, along with the beginnings of an ITCSS structure, but this PR only address styles that pertain to the header, and some basic HTML elements
- [ ] Visit the [homepage](http://localhost:8080/)
- [ ] Inspect the header. Class names on elements should follow the BEM convention (i.e. `header-nav`, `header-nav__container`, `header-nav__link-list`)
- [ ] On small screens, the header should collapse so that the MH logo is on top of the 3 links
- [ ] On larger screens, the header will expand so that MH logo is on the left, with the 3 links on the right. At ultra-wide screen sizes, you should see the `header-nav__container` max out in width.
- [ ] Button hovers should be visible (although they do not reach minimum contrast standards)