### PR TITLE
Refactor:  homepage hero

### DIFF
--- a/cypress/e2e/animate-text.cy.js
+++ b/cypress/e2e/animate-text.cy.js
@@ -3,16 +3,16 @@ describe('animates the welcome messages', () => {
     cy.visit('/');
   });
   it('visits the homepage', () => {
-    cy.get('h1').should('have.text', "Welcome to my portfolio. I'm an educator turned Front End Developer.");
+    cy.get('.cmp-homepage-hero__heading').contains('Welcome to my portfolio. I\'m an educator turned Front End Developer.');
   });
   it('has an h2 with the class of typewriter and a data-type attribute', () => {
-    cy.get('.typewriter').should('have.attr', 'data-type');
+    cy.get('.js-typewriter').should('have.attr', 'data-type');
   });
   // TODO: this test may need to change once animate-text.js gets refactored
   it('cycles through multiple data-type values', () => {
-    cy.get('.wrap').should('have.text', '');
+    cy.get('.js-wrap').should('have.text', '');
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(2000);
-    cy.get('.wrap').should('not.have.text', '');
+    cy.get('.js-wrap').should('not.have.text', '');
   });
 });

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -33,18 +33,19 @@
   </header>
 
   <main class="cmp-body">
-    <div class="hero-section">
-      <div class="text">
+    <section class="cmp-homepage-hero">
+      <div class="cmp-homepage-hero__text">
         <div id="type-on">
-          <h2 class="typewriter" data-period="2000" data-type='[ "hi there!", "aloha!", "hello!", "hola!", "welcome!", "bonjour!"]'>
-          <span class="wrap"></span>
+          <h2 class="js-typewriter cmp-homepage-hero__typewriter" data-period="2000" data-type='[ "hi there!", "aloha!", "hello!", "hola!", "welcome!", "bonjour!"]'>
+          <span class="js-wrap"></span>
           </h2>
         </div>
-        {{ content | safe }}
+        <h1 class="{{ headingClass }}">
+          {{ heading }}
+        </h1>
       </div>
-    </div> 
-
-    {% image 'src/public/usedresources/Arrow 1.png', 'arrow', 'Scroll Down'%}
+        {% image 'src/public/usedresources/Arrow 1.png', 'cmp-homepage-hero__arrow', 'Scroll Down' %}
+    </section> 
 
     <section class="about-me">
       <div class="text-container">

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -1,6 +1,10 @@
 ---
 title: Marissa Huysentruyt
 layout: base.njk
+headingClass: 'cmp-homepage-hero__heading'
+heading: |
+  Welcome to my portfolio. I'm an educator turned Front End Developer.
+introClass: 'intro__text'
 intro: |
   My name is Marissa and I'm starting my second career as a web developer! I've been working in public education for the last 6 years, and recently started dabbling in development. I really enjoy the problem-solving aspect and detail-driven nature of building user-friendly interfaces! Feel free to poke around my portfolio here, and shoot me an email if I can answer any questions!
 collabText:
@@ -8,5 +12,3 @@ collabText:
   bold: Shoot me a message!
   linkText: Get in Touch
 ---
-
-# Welcome to my portfolio. I'm an educator turned Front End Developer.

--- a/src/scripts/animate-text.js
+++ b/src/scripts/animate-text.js
@@ -20,7 +20,7 @@ TypeText.prototype.tick = function typeTextTick() {
     this.txt = fullTxt.substring(0, this.txt.length + 1);
   }
 
-  this.elem.innerHTML = `<span class="wrap">${this.txt}</span>`;
+  this.elem.innerHTML = `<span class="js-wrap">${this.txt}</span>`;
 
   const that = this;
   let delta = 200 - Math.random() * 100;
@@ -44,7 +44,7 @@ TypeText.prototype.tick = function typeTextTick() {
 };
 
 window.onload = function onLoad() {
-  const elements = document.getElementsByClassName('typewriter');
+  const elements = document.getElementsByClassName('js-typewriter');
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < elements.length; i++) {
     const toRotate = elements[i].getAttribute('data-type');
@@ -58,5 +58,5 @@ window.onload = function onLoad() {
 };
 
 const css = document.createElement('style');
-css.innerHTML = '.typewriter > .wrap {border-right: 0.06em solid rgba(255, 255, 255, 0.24);}';
+css.innerHTML = '.js-typewriter > .js-wrap {border-right: 0.06em solid rgba(255, 255, 255, 0.24);}';
 document.body.appendChild(css);

--- a/src/scripts/animate-text.spec.js
+++ b/src/scripts/animate-text.spec.js
@@ -3,8 +3,8 @@
  */
 
 describe('animate-text', () => {
-  it('has at least 1 element that has a class of "typewriter"', () => {
-    const elements = document.getElementsByClassName('typewriter');
+  it('has at least 1 element that has a class of "js-typewriter"', () => {
+    const elements = document.getElementsByClassName('js-typewriter');
     expect(elements).not.toBeNull();
   });
 });

--- a/src/scss/_homepage-hero.scss
+++ b/src/scss/_homepage-hero.scss
@@ -1,0 +1,83 @@
+@use './general/general';
+
+.cmp-homepage-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 2rem 1.5rem;
+  position: relative;
+
+  @media (min-width: general.$bp-medium) {
+    max-width: general.$max-page-width;
+    margin: auto;
+    padding: 5rem 1.5rem;
+  }
+
+  // this is the container for the typewriter (h2) & h1 heading
+  &__text {
+    width: 100%;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  &__typewriter {
+    width: 100%;
+    box-sizing: border-box;
+    text-align: left;
+    font-size: 3rem;
+    color: hsla(var(--color-white) / 0.72);
+    margin: 0 auto;
+    // TODO: refactor javascript animate-text, to use CSS animations instead?
+    // animation: type-on 2.5s steps(50, end) alternate infinite,
+    // blink-cursor 0.75s step-end infinite;
+
+    @media (min-width: general.$bp-small) {
+      font-size: 4rem;
+    }
+
+    @media (min-width: general.$bp-medium) {
+      font-size: 6rem;
+    }
+
+    @media (min-width: general.$bp-large) {
+      font-size: 10rem;
+    }
+  }
+
+  &__heading {
+    color: hsla(var(--color-white) / 0.88);
+    font-size: 1.5rem;
+    text-wrap: balance;
+
+    @media (min-width: general.$bp-medium) {
+      font-size: 2.5rem;
+      max-width: 70%;
+    }
+  }
+
+  &__arrow {
+    display: none;
+
+    @media (min-width: general.$bp-medium) {
+      display: block;
+      position: absolute;
+      left: 90%;
+      top: 70%;
+      animation: arrowBounce 1s ease-in-out alternate infinite;
+
+      @media (prefers-reduced-motion) {
+        animation: none;
+      }
+    }
+
+    // TODO: can we get rid of this 3rem somehow?
+    @media (min-width: calc(general.$max-page-width + 3rem)) {
+      left: 100%;
+    }
+  }
+}
+

--- a/src/scss/_homepage-hero.scss
+++ b/src/scss/_homepage-hero.scss
@@ -29,8 +29,9 @@
     box-sizing: border-box;
     text-align: left;
     font-size: 3rem;
-    color: hsla(var(--color-white) / 0.72);
+    color: hsla(var(--color-white) / 72%);
     margin: 0 auto;
+    
     // TODO: refactor javascript animate-text, to use CSS animations instead?
     // animation: type-on 2.5s steps(50, end) alternate infinite,
     // blink-cursor 0.75s step-end infinite;
@@ -49,7 +50,7 @@
   }
 
   &__heading {
-    color: hsla(var(--color-white) / 0.88);
+    color: hsla(var(--color-white) / 88%);
     font-size: 1.5rem;
     text-wrap: balance;
 
@@ -67,7 +68,7 @@
       position: absolute;
       left: 90%;
       top: 70%;
-      animation: arrowBounce 1s ease-in-out alternate infinite;
+      animation: arrow-bounce 1s ease-in-out alternate infinite;
 
       @media (prefers-reduced-motion) {
         animation: none;

--- a/src/scss/general/_general.scss
+++ b/src/scss/general/_general.scss
@@ -2,6 +2,7 @@
 $max-page-width: 75rem;
 $bp-small: 30rem;
 $bp-medium: 50rem;
+$bp-large: 70rem;
 $header-height: 8rem;
 $pill-border-radius: 3rem;
 $default-transition: all ease-in-out 0.2s;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,6 +1,7 @@
 // SETTINGS
 
 // TOOLS
+@forward './tools/animations';
 
 // GENERAL
 @forward './general/general';
@@ -18,6 +19,7 @@
 @forward './components/header';
 @forward './components/body';
 @forward './components/footer';
+@forward './homepage-hero';
 @forward './components/blog-page';
 @forward './components/contact-page';
 @forward './components/resume-page';
@@ -37,15 +39,6 @@
     height: 100%;
 }
 
-.cmp-body .hero-section {
-    display: flex;
-    flex-basis: 80%;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-    padding: 7.5%;
-}
-
 /* css animations */
 
 /* @keyframes type-on {
@@ -59,43 +52,7 @@
     100% { border-color: transparent}
 } */
 
-.cmp-body .hero-section .text {
-    width: 100%;
-    margin: 0;
-}
-
-.cmp-body .hero-section h2 {
-    padding: 10% 0 5%;
-    text-align: left;
-    font-size: 200px;
-    color: rgba(255 255 255 / 72%);
-    flex-shrink: 1;
-    flex-grow: 0;
-    overflow: hidden;
-    border-right: 0.06em solid transparent;
-    white-space: nowrap;
-    margin: 0 auto;
-}
-
-.cmp-body .hero-section h1 {
-    width: 55%;
-    font-size: 2em;
-    color: rgba(255 255 255 / 88%);
-    line-height: 140%;
-}
-
 // stylelint-disable-next-line keyframes-name-pattern
-@keyframes arrowBounce {
-    0% {top: -1.75em;}
-    100% {top: -4em;}
-}
-
-.cmp-body img.arrow {
-    position: relative;
-    left: 90%;
-    top: -1.75em;
-    animation: arrowBounce 1s ease-in-out alternate infinite;
-}
 
 .cmp-body .about-me {
     background-color:#fff6f6;
@@ -404,14 +361,6 @@
 /* responsive/mobile */
 
 @media only screen and (max-width: 1220px) {
-    .hero-section h2 span {
-        font-size: 90%;
-     }
-
-    .cmp-body .hero-section h1 {
-        width: 70%;
-    }
-
     .neverland-travelers .nt-text .links a.link1,
     .financial .fin-text .links a.link1, 
     .iceland .ice-text .links a.link1 {
@@ -430,20 +379,12 @@
 } 
 
 @media only screen and (max-width: 1000px) {
-    .hero-section h2 span {
-        font-size: 80%;
-     }
-
     .projects h2 {
         font-size: 180px;
     }
 }
 
 @media only screen and (max-width: 900px) {
-     .hero-section h2 span {
-        font-size: 72%;
-     }
-
      .collab-cta p {
          flex-basis: 60%;
      }
@@ -457,16 +398,8 @@
 
 
 @media only screen and (max-width: 768px) {
-    .hero-section h2 span {
-        font-size: 60%;
-    }
-
-    .cmp-body .hero-section h1 {
-        width: 100%;
-        margin-bottom: 10%;
-    }
-
     .cmp-body .about-me {
+        /* border: 1px solid red; */
         flex-direction: column-reverse;
     }
     
@@ -542,22 +475,7 @@
     }
 }
 
-@media only screen and (max-width: 640px) {
-    .hero-section h2 span {
-        font-size: 45%;
-    }
-}
-
 @media only screen and (max-width: 500px) {
-    .hero-section h2 span {
-        font-size: 40%;
-        margin-top: 20%;
-        }
-
-    .cmp-body .hero-section h1 {
-        font-size: 1.5em;
-    }
-
     .cmp-body .about-me .text-container::before {
         right: 55%;
         top: -55%;
@@ -594,10 +512,6 @@
 }
 
 @media only screen and (max-width: 414px) {
-    .hero-section h2 span {
-        font-size: 30%;
-    }
-
     .cmp-body .about-me .text-container::before {
         right: 35%;
         top: -35%;
@@ -610,11 +524,5 @@
 
      .collab-cta a {
          width: 70%;
-     }
-}
-
-@media only screen and (max-width: 325px) {
-    .hero-section h2 span {
-        font-size: 22%;
      }
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -33,11 +33,6 @@
 // UTILITIES
 
 // ===============
-.cmp-body {
-    padding: 0;
-    background-color: var(--color-dark-teal);
-    height: 100%;
-}
 
 /* css animations */
 

--- a/src/scss/tools/_animations.scss
+++ b/src/scss/tools/_animations.scss
@@ -1,0 +1,29 @@
+@keyframes arrowBounce {
+  0% {
+    top: 75%;
+  }
+  100% {
+    top: 85%;
+  }
+}
+
+@keyframes type-on {
+  from { 
+    width: 0;
+  }
+  to { 
+    width: 100%;
+  }
+}
+
+@keyframes blink-cursor {
+  to { 
+    border-color: transparent;
+  }
+  50% { 
+    border-color: var(--color-bright-coral);
+  }
+  100% { 
+    border-color: transparent;
+  }
+}

--- a/src/scss/tools/_animations.scss
+++ b/src/scss/tools/_animations.scss
@@ -1,7 +1,8 @@
-@keyframes arrowBounce {
+@keyframes arrow-bounce {
   0% {
     top: 75%;
   }
+
   100% {
     top: 85%;
   }
@@ -11,18 +12,21 @@
   from { 
     width: 0;
   }
+
   to { 
     width: 100%;
   }
 }
 
 @keyframes blink-cursor {
-  to { 
+  0% { 
     border-color: transparent;
   }
+
   50% { 
     border-color: var(--color-bright-coral);
   }
+
   100% { 
     border-color: transparent;
   }


### PR DESCRIPTION
This PR continues to refactor the homepage with new markup and transfers styles to SCSS partials. The focus of this PR is on the `cmp-homepage-hero` elements.

- creates `_homepage-hero.scss` & `_animations.scss` partials
- imports new partials into `main.scss`
- adds pertinent styles to` _homepage-hero.scss`
- includes BEM class naming in markup

This should be almost an exact parity of the current site design.

![Home](https://github.com/marissahuysentruyt/marissahuysentruyt/assets/69602589/ec2fc643-ce5a-4b89-87cd-6c89a03d20d1)

### Validation
- [ ] Pull down the branch
- [ ] Run `npm install`, then `npm start`
- [ ] In your editor, find the `src/scss` directory. The `main.scss` fille still has vanilla CSS included, along with the beginnings of an ITCSS structure, but this PR only removes styles that pertain to the hero or arrow animation
- [ ] Visit the [homepage](http://localhost:8080/)
- [ ] Inspect the hero section. Class names on elements should follow the BEM convention (i.e. `cmp-homepage-hero`, `cmp-homepage-hero__text`, `js-typewriter`, etc.)
- [ ] On all screen sizes, the hero text should not overflow.
- [ ] Change the screen size and ensure that visually, nothing in the hero breaks. Most elements go from smaller text to larger text. The bouncing arrow only appears at larger screen sizes.