### PR TITLE
Refactor: about section

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -47,20 +47,20 @@
         {% image 'src/public/usedresources/Arrow 1.png', 'cmp-homepage-hero__arrow', 'Scroll Down' %}
     </section> 
 
-    <section class="about-me">
-      <div class="text-container">
-        <p>
+    <section class="cmp-about">
+      <div class="cmp-about__container">
+        <div class="cmp-about__image-container">
+          {% image 'src/public/usedresources/cropped_IMG_2512.png', 'cmp-about__image', 'Marissa with a big smile, harnessed while on an outdoor excursion' %}
+        </div>
+        <p class="cmp-about__text">
           {{ intro }}
         </p>
       </div>
-      <div class="image-container">
-        {% image 'src/public/usedresources/cropped_IMG_2512.png', 'me', 'Photo of Marissa' %}
-      </div>
     </section> 
-      
-    <section id="projects" class="projects">
-      <h2>Projects</h2>
-      <div class="grid">
+        
+      <section id="projects" class="projects">
+        <h2>Projects</h2>
+        <div class="grid">
 
         <!-- neverland travelers -->
         <div class="neverland-travelers">

--- a/src/scss/components/_about-section.scss
+++ b/src/scss/components/_about-section.scss
@@ -1,0 +1,85 @@
+@use '../general/general';
+
+.cmp-about {
+  background-color: var(--color-light-peach);
+  padding: 2rem 1.5rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  position: relative;
+  z-index: 2;
+
+  @media (min-width: general.$bp-medium) {
+    padding: 5rem 1.5rem;
+  }
+
+  &::before,
+  &::after {
+    position: absolute;
+    content: "";
+    z-index: -1;
+    border-radius: 50%;
+  }
+
+  &::before {
+    height: 18.25rem; // 292px
+    width: 18.25rem; // 292px
+    background-color: var(--color-bright-coral-transparent);
+    left: -9rem;
+    top: 18rem;
+
+    @media (min-width: general.$bp-medium) {
+      left: -4rem;
+      top: 15rem;
+    }
+  }
+
+  &::after {
+    height: 32.125rem; // 514px
+    width: 32.125rem; // 514px
+    background-color: hsla(var(--color-white) / 100%);
+    bottom: -14rem;
+    right: -10rem;
+
+    @media (min-width: general.$bp-medium) {
+      top: -4rem;
+    }
+  } 
+  
+  &__container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+
+    @media (min-width: general.$bp-medium) {
+      flex-direction: row;
+      justify-content: space-between;
+      margin: auto;
+      max-width: general.$max-page-width;
+    }
+  }
+
+  &__text {
+    font-size: 1.5em;
+    line-height: 1.5;
+    margin: 0;
+    text-wrap: balance;
+    position: relative;
+
+    @media (min-width: general.$bp-medium) {
+      max-width: 50%;
+    }
+  }
+
+  &__image-container {
+    z-index: 3;
+  }
+
+  &__image {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    position: relative;
+  }
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -20,6 +20,7 @@
 @forward './components/body';
 @forward './components/footer';
 @forward './components/homepage-hero';
+@forward './components/about-section';
 @forward './components/contact-section';
 @forward './components/blog-page';
 @forward './components/contact-page';
@@ -33,85 +34,6 @@
 
 // UTILITIES
 @forward './utilities/bold';
-
-// ===============
-
-/* css animations */
-
-/* @keyframes type-on {
-    from { width: 0}
-    to { width: 100%}
-}
-
-@keyframes blink-cursor {
-    from, to { border-color: transparent}
-    50% { border-color: #F36748}
-    100% { border-color: transparent}
-} */
-
-// stylelint-disable-next-line keyframes-name-pattern
-
-.cmp-body .about-me {
-    background-color:#fff6f6;
-    padding: 7.5% 7.5% 12%;
-    display: flex;
-    flex-direction: row-reverse;
-    align-items: center;
-    justify-content: space-between;
-    overflow: hidden;
-}
-
-.cmp-body .about-me .text-container {
-    font-size: 1.5em;
-    line-height: 1.5em;
-    font-weight: 400;
-
-    // grow, shrink, basis
-    flex: 0 1 60%;
-    z-index: 4;
-    padding-left: 7.5%;
-    position: relative;
-}
-
-.cmp-body .about-me .image-container {
-    flex-basis: 40%;
-    z-index: 4;
-    padding: 0;
-}
-
-.cmp-body .about-me .image-container img {
-    width: 100%;
-    height: auto;
-    border-radius: 50%;
-    position: relative;
-    z-index: 3;
-}
-
-.cmp-body .about-me .text-container::before {
-    content: " ";
-    display: inline;
-    height: 292px;
-    width: 292px;
-    background-color: #FFCEC6;
-    border-radius: 50%;
-    position: absolute;
-    right: 150%;
-    top: 50px;
-    z-index: -1;
-}
-
-.cmp-body .about-me .text-container::after {
-    content: " ";
-    height: 513px;
-    width: 513px;
-    background-color: #fff;
-    border-radius: 50%;
-    position: absolute;
-    top: -275px;
-    left: 60%;
-    z-index: -1;
-    display: inline;
-} 
 
 .projects {
     padding-top: 5%;
@@ -340,31 +262,7 @@
 }
 
 
-@media only screen and (max-width: 768px) {
-    .cmp-body .about-me {
-        /* border: 1px solid red; */
-        flex-direction: column-reverse;
-    }
-    
-    .cmp-body .about-me .text-container {
-        flex-basis: 100%;
-        z-index: 4;
-        padding: 10% 0 0;
-        position: relative;
-    }
-    
-    .cmp-body .about-me .text-container::before {
-        right: 75%;
-        top: -155%;
-        z-index: -1;
-    }
-    
-    .cmp-body .about-me .text-container::after {
-        top: -275px;
-        left: 60%;
-        z-index: -1;
-    }  
-
+@media only screen and (max-width: 768px) {  
     .projects h2 {
         font-size: 120px;
     }
@@ -406,18 +304,6 @@
 }
 
 @media only screen and (max-width: 500px) {
-    .cmp-body .about-me .text-container::before {
-        right: 55%;
-        top: -55%;
-        z-index: -1;
-    }
-    
-    .cmp-body .about-me .text-container::after {
-        top: -10%;
-        left: 40%;
-        z-index: -1;
-    } 
-
     .projects h2 {
     font-size: 6em;
     }
@@ -442,12 +328,6 @@
 }
 
 @media only screen and (max-width: 414px) {
-    .cmp-body .about-me .text-container::before {
-        right: 35%;
-        top: -35%;
-        z-index: -1;
-    }
-
     .projects h2 {
         font-size: 4.5em;
      }


### PR DESCRIPTION
This PR continues to refactor the homepage with new markup and transfers styles to SCSS partials. The focus of this PR is on the `cmp-about` elements.

- use BEM naming convention for classes
- extract all about-section styles to about-section.scss partial
- add lighter color custom property to root.scss
- add better alt text for image
- import all new styles to main.scss

This should be almost an exact parity of the current site design.

![Home](https://github.com/marissahuysentruyt/marissahuysentruyt/assets/69602589/ec2fc643-ce5a-4b89-87cd-6c89a03d20d1)

### Validation
- [ ] Pull down the branch
- [ ] Run `npm install`, then `npm start`
- [ ] In your editor, find the `src/scss` directory. The `main.scss` fille still has vanilla CSS included, along with the beginnings of an ITCSS structure, but this PR only removes styles that pertain to the about section under the hero.
- [ ] Visit the [homepage](http://localhost:8080/)
- [ ] Inspect the about section. Class names on elements should follow the BEM convention (i.e. `cmp-about`, `cmp-about__text`, `cmp-about__image-container`, etc.).
- [ ] Change the screen size and ensure that visually, nothing in the about section breaks. The image should stack vertically on top of the text for small screens, then reorient to the left side of the screen, center aligned with the text on the right.