### PR TITLE
Feat: max width class

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -14,7 +14,7 @@
 
 <body>
   <header class="cmp-header">
-    <nav class="cmp-header__container">
+    <nav class="cmp-header__container util-max-width">
       <a href="/index.html" class="cmp-header__home-link">
         {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
       </a>
@@ -33,7 +33,7 @@
   </header>
 
   <main class="cmp-body">
-    <section class="cmp-homepage-hero">
+    <section class="cmp-homepage-hero util-max-width">
       <div class="cmp-homepage-hero__text">
         <div id="type-on">
           <h2 class="js-typewriter cmp-homepage-hero__typewriter" data-period="2000" data-type='[ "hi there!", "aloha!", "hello!", "hola!", "welcome!", "bonjour!"]'>
@@ -48,7 +48,7 @@
     </section> 
 
     <section class="cmp-about">
-      <div class="cmp-about__container">
+      <div class="cmp-about__container util-max-width">
         <div class="cmp-about__image-container">
           {% image 'src/public/usedresources/cropped_IMG_2512.png', 'cmp-about__image', 'Marissa with a big smile, harnessed while on an outdoor excursion' %}
         </div>
@@ -59,7 +59,7 @@
     </section> 
         
       <section id="projects" class="cmp-projects">
-        <div class="cmp-projects__container">
+        <div class="cmp-projects__container util-max-width">
           <h2 class="cmp-projects__heading">Projects</h2>
 
           <div class="obj-projects-grid">
@@ -140,7 +140,7 @@
       </section>
 
     <section class="cmp-contact">
-      <div class="cmp-contact__container">
+      <div class="cmp-contact__container util-max-width">
         <p class="cmp-contact__text">
           {{ collabText.paragraph }} <strong class="util-bold">{{ collabText.bold }}</strong>
         </p>

--- a/src/layouts/blog.njk
+++ b/src/layouts/blog.njk
@@ -14,7 +14,7 @@
 <body>
 
   <header class="cmp-header">
-    <nav class="cmp-header__container">
+    <nav class="cmp-header__container util-max-width">
       <a href="/index.html" class="cmp-header__home-link">
         {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
       </a>
@@ -33,7 +33,7 @@
   </header>
 
   <main class="cmp-body">
-    <section class="hero-section--blog">
+    <section class="hero-section--blog util-max-width">
         <h2>blog</h2>
         <p>
             <!-- why am i writing these blogs -->
@@ -83,7 +83,7 @@
     </section>
     
     <section class="cmp-contact">
-      <div class="cmp-contact__container">
+      <div class="cmp-contact__container util-max-width">
         <p class="cmp-contact__text">
           {{ collabText.paragraph }} <strong class="util-bold">{{ collabText.bold }}</strong>
         </p>

--- a/src/layouts/contact.njk
+++ b/src/layouts/contact.njk
@@ -14,7 +14,7 @@
 <body>
 
     <header class="cmp-header">
-      <nav class="cmp-header__container">
+      <nav class="cmp-header__container util-max-width">
         <a href="/index.html" class="cmp-header__home-link">
           {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
         </a>

--- a/src/layouts/project-page.njk
+++ b/src/layouts/project-page.njk
@@ -14,7 +14,7 @@
 <body>
 
     <header class="cmp-header">
-      <nav class="cmp-header__container">
+      <nav class="cmp-header__container util-max-width">
         <a href="/index.html" class="cmp-header__home-link">
           {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
         </a>
@@ -102,7 +102,7 @@
        </section>
                 
       <section class="cmp-contact">
-        <div class="cmp-contact__container">
+        <div class="cmp-contact__container util-max-width">
           <p class="cmp-contact__text">
             {{ collabText.paragraph }} <strong class="util-bold">{{ collabText.bold }}</strong>
           </p>

--- a/src/layouts/resume.njk
+++ b/src/layouts/resume.njk
@@ -14,7 +14,7 @@
 <body>
 
     <header class="cmp-header">
-      <nav class="cmp-header__container">
+      <nav class="cmp-header__container util-max-width">
         <a href="/index.html" class="cmp-header__home-link">
           {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
         </a>
@@ -193,7 +193,7 @@
         </div>
 
       <section class="cmp-contact">
-        <div class="cmp-contact__container">
+        <div class="cmp-contact__container util-max-width">
           <p class="cmp-contact__text">
             {{ collabText.paragraph }} <strong class="util-bold">{{ collabText.bold }}</strong>
           </p>

--- a/src/layouts/work-examples.njk
+++ b/src/layouts/work-examples.njk
@@ -13,33 +13,33 @@
 </head>
 <body>
 
-    <header class="cmp-header">
-      <nav class="cmp-header__container">
-        <a href="/index.html" class="cmp-header__home-link">
-          {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
-        </a>
-        <ul class="cmp-header__link-list">
-          <li class="cmp-header__list-item">
-            <a class="cmp-header__link" href="/work/work-examples.html">Projects</a>
-          </li>
-          <li class="cmp-header__list-item">
-            <a class="cmp-header__link" href="/resume/resume.html">Resume</a>
-          </li>
-          <li class="cmp-header__list-item">
-            <a class="cmp-header__link" href="/contact/contact.html">Contact</a>
-          </li>
-        </ul>
-      </nav>
-    </header>
-    
-    <main class="cmp-body--projects">
+  <header class="cmp-header">
+    <nav class="cmp-header__container util-max-width">
+      <a href="/index.html" class="cmp-header__home-link">
+        {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
+      </a>
+      <ul class="cmp-header__link-list">
+        <li class="cmp-header__list-item">
+          <a class="cmp-header__link" href="/work/work-examples.html">Projects</a>
+        </li>
+        <li class="cmp-header__list-item">
+          <a class="cmp-header__link" href="/resume/resume.html">Resume</a>
+        </li>
+        <li class="cmp-header__list-item">
+          <a class="cmp-header__link" href="/contact/contact.html">Contact</a>
+        </li>
+      </ul>
+    </nav>
+  </header>
+  
+  <main class="cmp-body--projects">
 
-        <section class="hero-section--projects">
-            <h2>projects</h2>
-            <h1>Below are some of the projects I've worked on. Feel free to browse around, and click into any of these projects for more details on what I contributed during each, what technologies I used to create them, and any other important notes. You can also find links to the GitHub Repos, any CodePens, or live sites.</h1>
-        </section>
+      <section class="hero-section--projects">
+          <h2>projects</h2>
+          <h1>Below are some of the projects I've worked on. Feel free to browse around, and click into any of these projects for more details on what I contributed during each, what technologies I used to create them, and any other important notes. You can also find links to the GitHub Repos, any CodePens, or live sites.</h1>
+      </section>
 
-        <section class="projects">
+      <section class="projects">
 
             <div class="grid">
                 <!-- neverland travelers -->
@@ -61,10 +61,10 @@
                         </div>
                     </div>
 
-                    <div class="nt-screenshot">
-                      {% image 'src/public/usedresources/NT-screenshot-hp.png', '', 'Neverland Travelers Screenshot'%}
-                    </div>
-                </div>
+                  <div class="nt-screenshot">
+                    {% image 'src/public/usedresources/NT-screenshot-hp.png', '', 'Neverland Travelers Screenshot'%}
+                  </div>
+              </div>
 
                 <!-- greg parady remake -->
                 <div class="financial">
@@ -113,17 +113,17 @@
                 </div>
             </div>
 
-        </section>
-
-      <section class="cmp-contact">
-        <div class="cmp-contact__container">
-          <p class="cmp-contact__text">
-            {{ collabText.paragraph }} <strong class="util-bold">{{ collabText.bold }}</strong>
-          </p>
-          <a class="cmp-button cmp-button--primary" href="/contact/contact.html">{{ collabText.linkText }}</a>
-        </div>
       </section>
-    </main>
+
+    <section class="cmp-contact">
+      <div class="cmp-contact__container util-max-width">
+        <p class="cmp-contact__text">
+          {{ collabText.paragraph }} <strong class="util-bold">{{ collabText.bold }}</strong>
+        </p>
+        <a class="cmp-button cmp-button--primary" href="/contact/contact.html">{{ collabText.linkText }}</a>
+      </div>
+    </section>
+  </main>
 
   <footer class="cmp-footer">
     <ul class="cmp-footer__link-list">

--- a/src/scss/components/_about-section.scss
+++ b/src/scss/components/_about-section.scss
@@ -54,8 +54,6 @@
     @media (min-width: general.$bp-medium) {
       flex-direction: row;
       justify-content: space-between;
-      margin: auto;
-      max-width: general.$max-page-width;
     }
   }
 

--- a/src/scss/components/_contact-section.scss
+++ b/src/scss/components/_contact-section.scss
@@ -11,18 +11,15 @@
   }
   
   &__container {
-    width: 100%;
     display: flex;
     gap: 3rem;
     align-items: flex-start;
     flex-direction: column;
     
     @media (min-width: general.$bp-medium) {
-      margin: auto;
       flex-direction: row;
       align-items: center;
       justify-content: space-between;
-      max-width: general.$max-page-width;
     }
   }
 

--- a/src/scss/components/_header.scss
+++ b/src/scss/components/_header.scss
@@ -20,8 +20,6 @@
     justify-content: space-between;
 
     @media (min-width: general.$bp-medium) {
-      max-width: general.$max-page-width;
-      margin: auto;
       flex-direction: row;
     }
   }

--- a/src/scss/components/_homepage-hero.scss
+++ b/src/scss/components/_homepage-hero.scss
@@ -10,8 +10,6 @@
   position: relative;
 
   @media (min-width: general.$bp-medium) {
-    max-width: general.$max-page-width;
-    margin: auto;
     padding: 5rem 1.5rem;
   }
 

--- a/src/scss/layouts/_projects-grid.scss
+++ b/src/scss/layouts/_projects-grid.scss
@@ -14,8 +14,6 @@
     gap: 6rem;
     grid-template-columns: unset;
     grid-template-rows: repeat(3, 1fr);
-    max-width: general.$max-page-width;
-    margin: auto;
   }
   
   &__item {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -37,3 +37,4 @@
 
 // UTILITIES
 @forward './utilities/bold';
+@forward './utilities/max-width';

--- a/src/scss/utilities/_max-width.scss
+++ b/src/scss/utilities/_max-width.scss
@@ -1,0 +1,10 @@
+@use '../general/general';
+
+.util-max-width {
+  width: 100%;
+
+  @media (min-width: general.$bp-medium) {
+    max-width: general.$max-page-width;
+    margin: auto;
+  }
+}


### PR DESCRIPTION
This PR continues to refactor the homepage with new markup and transfers styles to SCSS partials. The focus of this PR is on the elements that have a max-width. 

**NOTE:** This PR doesn't address broken interior page styles. Those will be taken care of in subsequent refactoring PRs!

-Add a util-max-width class & max-width.scss partial to handle all sections that have a max-width
-remove styles that would be duplicating the purpose of the max-width class
-import to main.scss
-put util-max-width class on containers that have a max-width on all pages

This should be almost an exact parity of the current site design.

![Home](https://github.com/marissahuysentruyt/marissahuysentruyt/assets/69602589/ec2fc643-ce5a-4b89-87cd-6c89a03d20d1)

### Validation
- [ ] Pull down the branch
- [ ] Run `npm install`, then `npm start`
- [ ] Visit the [homepage](http://localhost:8080/)
- [ ] Inspect the sections listed below. Verify the `util-max-width` class appears on the:

| section | element |
| --- | --- |
| header | `cmp-header__container` |
| hero | `cmp-homepage-hero` |
| about | `cmp-about__container` |
| projects | `cmp-projects__container` |
| contact | `cmp-contact__container` |

- [ ] When applicable, verify the `util-max-width` class is found on the header and contact sections on the interior pages ([blog](http://localhost:8080/blog/blog.html), [work page](http://localhost:8080/work/work-examples.html), project page templates like the [Neverland Travelers page](http://localhost:8080/work/neverland-travelers.html), [resume](http://localhost:8080/resume/resume.html) and [contact page](http://localhost:8080/contact/contact.html)).