### PR TITLE
Fix: adds missing font styles & header classes

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -8,25 +8,25 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Raleway:wght@400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/main.css" type="text/css">
-  <link rel="icon" href="public/usedresources/favicon.png" type="image/png">
+  <link rel="stylesheet" href="/css/main.css" type="text/css">
+  <link rel="icon" href="/public/usedresources/favicon.png" type="image/png">
 </head>
 
 <body>
   <header class="cmp-header">
     <nav class="cmp-header__container">
-      <a href="index.html" class="cmp-header__home-link">
+      <a href="/index.html" class="cmp-header__home-link">
         {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
       </a>
       <ul class="cmp-header__link-list">
         <li class="cmp-header__list-item">
-          <a class="cmp-header__link" href="work/work-examples.html">Projects</a>
+          <a class="cmp-header__link" href="/work/work-examples.html">Projects</a>
         </li>
         <li class="cmp-header__list-item">
-          <a class="cmp-header__link" href="resume/resume.html">Resume</a>
+          <a class="cmp-header__link" href="/resume/resume.html">Resume</a>
         </li>
         <li class="cmp-header__list-item">
-          <a class="cmp-header__link" href="contact/contact.html">Contact</a>
+          <a class="cmp-header__link" href="/contact/contact.html">Contact</a>
         </li>
       </ul>
     </nav>

--- a/src/layouts/blog.njk
+++ b/src/layouts/blog.njk
@@ -1,27 +1,36 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Blog</title>
-    <link rel="stylesheet" type="text/css" href="../css/main.css">
-    <link rel="icon" href="../../public/usedresources/favicon.png" type="image/png">
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Raleway:wght@400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/main.css" type="text/css">
+  <link rel="icon" href="/public/usedresources/favicon.png" type="image/png">
 </head>
 <body>
 
-<header>
-    <nav class="header-nav">
-        <a href="../index.html">
+  <header class="cmp-header">
+    <nav class="cmp-header__container">
+      <a href="/index.html" class="cmp-header__home-link">
         {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
-        </a>
-        <ul>
-            <li><a href="../work/work-examples.html">Projects</a></li>
-            <li><a href="../resume/resume.html">Resume</a></li>
-            <li><a href="../contact/contact.html">Contact</a></li>
-        </ul>
+      </a>
+      <ul class="cmp-header__link-list">
+        <li class="cmp-header__list-item">
+          <a class="cmp-header__link" href="/work/work-examples.html">Projects</a>
+        </li>
+        <li class="cmp-header__list-item">
+          <a class="cmp-header__link" href="/resume/resume.html">Resume</a>
+        </li>
+        <li class="cmp-header__list-item">
+          <a class="cmp-header__link" href="/contact/contact.html">Contact</a>
+        </li>
+      </ul>
     </nav>
-</header>
+  </header>
 
 <main class="body-container">
     <section class="hero-section--blog">

--- a/src/layouts/contact.njk
+++ b/src/layouts/contact.njk
@@ -1,26 +1,35 @@
 <!DOCTYPE html>
 <html lang="en"> 
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact Page</title>
-    <link rel="stylesheet" href="../css/main.css" type="text/css">
-    <link rel="icon" href="../../public/usedresources/favicon.png" type="image/png">
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Raleway:wght@400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/main.css" type="text/css">
+  <link rel="icon" href="/public/usedresources/favicon.png" type="image/png">
 </head>
 <body>
 
-    <header>
-        <nav class="header-nav">
-            <a href="../index.html">
-            {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
-            </a>
-            <ul>
-                <li><a href="../work/work-examples.html">Projects</a></li>
-                <li><a href="../resume/resume.html">Resume</a></li>
-                <li><a href="contact.html">Contact</a></li>
-            </ul>
-        </nav>
+    <header class="cmp-header">
+      <nav class="cmp-header__container">
+        <a href="/index.html" class="cmp-header__home-link">
+          {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
+        </a>
+        <ul class="cmp-header__link-list">
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/work/work-examples.html">Projects</a>
+          </li>
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/resume/resume.html">Resume</a>
+          </li>
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/contact/contact.html">Contact</a>
+          </li>
+        </ul>
+      </nav>
     </header>
 
     <main class="body-container body-container--contact-page">

--- a/src/layouts/project-page.njk
+++ b/src/layouts/project-page.njk
@@ -1,26 +1,35 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{title}}</title>
-    <link rel="stylesheet" href="../css/main.css" type="text/css">
-    <link rel="icon" href="../public/usedresources/favicon.png" type="image/png">
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Raleway:wght@400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/main.css" type="text/css">
+  <link rel="icon" href="../public/usedresources/favicon.png" type="image/png">
 </head>
 <body>
 
-    <header>
-        <nav class="header-nav">
-            <a href="../index.html">
-              {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
-            </a>
-            <ul>
-                <li><a href="work-examples.html">Projects</a></li>
-                <li><a href="../resume/resume.html">Resume</a></li>
-                <li><a href="../contact/contact.html">Contact</a></li>
-            </ul>
-        </nav>
+    <header class="cmp-header">
+      <nav class="cmp-header__container">
+        <a href="/index.html" class="cmp-header__home-link">
+          {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
+        </a>
+        <ul class="cmp-header__link-list">
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/work/work-examples.html">Projects</a>
+          </li>
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/resume/resume.html">Resume</a>
+          </li>
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/contact/contact.html">Contact</a>
+          </li>
+        </ul>
+      </nav>
     </header>
 
     <main class="{{bodyClass}}">

--- a/src/layouts/resume.njk
+++ b/src/layouts/resume.njk
@@ -1,35 +1,35 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{title}}</title>
-    <link rel="stylesheet" href="../css/main.css" type="text/css">
-    <link rel="icon" href="../../public/usedresources/favicon.png" type="image/png">
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Raleway:wght@400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/main.css" type="text/css">
+  <link rel="icon" href="/public/usedresources/favicon.png" type="image/png">
 </head>
 <body>
 
-    <header>
-        <nav class="header-nav">
-            <a href="../index.html">
-            {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
-            </a>
-            <ul>
-                <li><a href="../work/work-examples.html">Projects</a></li>
-                <li><a href="resume.html">Resume</a></li>
-                <li><a href="../contact/contact.html">Contact</a></li>
-            </ul>
-        </nav>
-
-        <!-- <div class="across-top">
-
-            <button type="button" class="download-btn" value="Download Resume">
-                Download Resume
-                <img src="../usedresources/download_arrow.svg" alt="Download">
-            </button>
-
-        </div> -->
+    <header class="cmp-header">
+      <nav class="cmp-header__container">
+        <a href="/index.html" class="cmp-header__home-link">
+          {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
+        </a>
+        <ul class="cmp-header__link-list">
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/work/work-examples.html">Projects</a>
+          </li>
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/resume/resume.html">Resume</a>
+          </li>
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/contact/contact.html">Contact</a>
+          </li>
+        </ul>
+      </nav>
     </header>
 
     <main class="body-container--resume">

--- a/src/layouts/work-examples.njk
+++ b/src/layouts/work-examples.njk
@@ -1,26 +1,35 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{title}}</title>
-    <link rel="stylesheet" href="../css/main.css" type="text/css">
-    <link rel="icon" href="../public/usedresources/favicon.png" type="image/png">
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Raleway:wght@400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/main.css" type="text/css">
+  <link rel="icon" href="/public/usedresources/favicon.png" type="image/png">
 </head>
 <body>
 
-    <header>
-        <nav class="header-nav">
-            <a href="../index.html">
-              {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
-            </a>
-            <ul>
-                <li><a href="work-examples.html">Projects</a></li>
-                <li><a href="../resume/resume.html">Resume</a></li>
-                <li><a href="../contact/contact.html">Contact</a></li>
-            </ul>
-        </nav>
+    <header class="cmp-header">
+      <nav class="cmp-header__container">
+        <a href="/index.html" class="cmp-header__home-link">
+          {% image 'src/public/usedresources/mh_logo.svg', '', 'Home'%}
+        </a>
+        <ul class="cmp-header__link-list">
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/work/work-examples.html">Projects</a>
+          </li>
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/resume/resume.html">Resume</a>
+          </li>
+          <li class="cmp-header__list-item">
+            <a class="cmp-header__link" href="/contact/contact.html">Contact</a>
+          </li>
+        </ul>
+      </nav>
     </header>
     
     <main class="body-container--projects">

--- a/src/pages/blog.md
+++ b/src/pages/blog.md
@@ -1,4 +1,5 @@
 ---
+title: Articles & Thoughts
 layout: blog.njk
 permalink: blog/blog.html
 ---


### PR DESCRIPTION
This PR adds the missing `link` elements for font styles and updates the headers & footers across pages that are not the homepage.

- add missing "Blog" `title` in MD file
- fixes leading `/` in paths for CSS & favicon
- adds all updated headers to Resume, Projects, Contact and Blog pages