### PR TITLE
Refactor: Remove grid areas

### DIFF
--- a/src/layouts/projects-grid.njk
+++ b/src/layouts/projects-grid.njk
@@ -1,6 +1,6 @@
 <div class="obj-projects-grid">
   {# neverland travelers vlog #}
-  <div class="obj-projects-grid__item obj-projects-grid__item--vlog">
+  <div class="obj-projects-grid__item">
     {# text container on left #}
     <div class="obj-projects-grid__item-text">
       <h3 class="obj-projects-grid__heading">
@@ -24,7 +24,7 @@
   </div>
 
   {# financial group remake #}
-  <div class="obj-projects-grid__item obj-projects-grid__item--remake">
+  <div class="obj-projects-grid__item">
     {# text container on right #}
     <div class="obj-projects-grid__item-text">
       <h3 class="obj-projects-grid__heading">
@@ -48,7 +48,7 @@
   </div>
 
   {# iceland travel landing page #}
-  <div class="obj-projects-grid__item obj-projects-grid__item--travel">
+  <div class="obj-projects-grid__item">
     {# text container on left #}
     <div class="obj-projects-grid__item-text">
       <h3 class="obj-projects-grid__heading">

--- a/src/scss/layouts/_projects-grid.scss
+++ b/src/scss/layouts/_projects-grid.scss
@@ -2,11 +2,6 @@
 
 .obj-projects-grid {
   display: grid;
-  grid-template-areas: 
-      "vlog"
-      "remake"
-      "travel";
-  grid-template-columns: 1fr;
   gap: 4rem;
   box-sizing: border-box;
 
@@ -29,18 +24,6 @@
       &:nth-child(even) {
         flex-direction: row-reverse;
       }
-    }
-
-    &--vlog {
-      grid-area: vlog;
-    }
-
-    &--remake {
-      grid-area: remake;
-    }
-
-    &--travel {
-      grid-area: travel;
     }
   }
 


### PR DESCRIPTION
# Description
- remove the class names with modifiers that relate to the grid areas. Grid areas aren't actually being used in the project-grid, so they aren't necessary.

## Specs

### Designs

This should be almost an exact parity of the current site design.

![Home](https://github.com/marissahuysentruyt/marissahuysentruyt/assets/69602589/ec2fc643-ce5a-4b89-87cd-6c89a03d20d1)

### Notes

## Validation

- [ ] Pull down the branch
- [ ] Run `npm install`, then `npm run start`
- [ ] Visit the [homepage](http://localhost:8080/)
- [ ] With the inspector, verify the projects section no longer contains elements with the class names: `obj-projects-grid__item--vlog`, `obj-projects-grid__item--travel`, `obj-projects-grid__item--remake` 
- [ ] Visit the [projects pages](http://localhost:8080/work/projects-overview-page.html)
- [ ] With the inspector, verify the included `project-grid` template no longer contains elements with the class names: `obj-projects-grid__item--vlog`, `obj-projects-grid__item--travel`, `obj-projects-grid__item--remake` 
