### PR TITLE
fix: correct the background and font color

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Description
+## Description
 <!-- Example: This PR continues to refactor the homepage with new markup and transfers styles to SCSS partials. The focus of this PR is on the cmp-contact elements. -->
 -
 -
@@ -8,21 +8,10 @@
 
 ### Designs
 
-<!-- This should be almost an exact parity of the current site design. -->
-
-<!-- example screenshot: ![Home](https://github.com/marissahuysentruyt/marissahuysentruyt/assets/69602589/ec2fc643-ce5a-4b89-87cd-6c89a03d20d1) -->
-
-### Notes
+### Notes/Pending Questions
 
 ## Validation
 
 - [ ] Pull down the branch
 - [ ] Run `npm install`, then `npm start`
-- [ ] In your editor, find the `src/scss` directory. The `main.scss` fille still has vanilla CSS included, along with the beginnings of an ITCSS structure, but this PR only removes styles that pertain to the contact section near the bottom of the page
 <!-- Write additional validation if needed. -->
-<!-- - [ ] Visit the [homepage](http://localhost:8080/) -->
-<!-- Example:
-- [ ] Inspect the contact section. Class names on elements should follow the BEM convention (i.e. `cmp-contact`, `cmp-contact__text`, `cmp-contact__link`, etc.). The text "Shoot Me a Message" should use the new utility class `util-bold`.
-- [ ] Inspect the "Get in Touch" button. It should use the new utility class `util-bold`.
-- [ ] Change the screen size and ensure that visually, nothing in the contact section breaks. The text should stack vertically on top of the button for small screens, then reorient to be horizontal, in line with the button.
-- [ ] Visit the [projects](http://localhost:8080/work/work-examples.html), [resume](http://localhost:8080/resume/resume.html), [contact](http://localhost:8080/contact/contact.html) and [blog](http://localhost:8080/blog/blog.html) pages. Verify the styles of the contact section behave the same as on the homepage. -->

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -102,6 +102,7 @@
     width: fit-content;
     font-size: 0.875rem;
     padding: 0.5rem 0.75rem;
+    margin: unset;
 
     &:hover {
       background-color: var(--color-bright-coral-transparent-8);

--- a/src/scss/components/_contact-section.scss
+++ b/src/scss/components/_contact-section.scss
@@ -10,6 +10,13 @@
     padding: 5rem 1.5rem;
   }
 
+  &--resume {
+    .cmp-contact {
+      background-color: var(--color-bright-coral-transparent-16);
+      color: hsla(var(--color-black) / 88%);
+    }
+  }
+
   .cmp-contact--vlog & {
     background-color: var(--color-purple);
     color: hsla(var(--color-white) / 88%);


### PR DESCRIPTION
## Description

The incorrect background color and text color within contact section on resume page are now corrected. Additionally, it updates the PR template.

## Specs

### Designs

This should be almost an exact parity of the current site design, but with fixed styles in the contact section.

![Screenshot 2024-04-16 at 11-39-30 Resume Marissa Huysentruyt](https://github.com/marissahuysentruyt/marissahuysentruyt/assets/69602589/df4b133d-139d-418c-9054-36fd29f308be)

### Notes

## Validation

- [ ] Pull down the branch
- [ ] Run `npm install`, then `npm start`
- [ ] Navigate to the [resume page](http://localhost:8080/resume/resume.html)
- [ ] Verify the background color of `.cmp-contact` within the `.cmp-contact--resume` section is the 16% transparent bright coral, and the text color is 88% black.
- [ ] Verify that at varying screen sizes, the "Download Resume" button stays pinned to the right side of the container. 

