### PR TITLE
feat: adds new typescript article link

### DIFF
--- a/src/layouts/blog-page.njk
+++ b/src/layouts/blog-page.njk
@@ -75,6 +75,11 @@
               11. The Apprentice(ship) Episode 5
             </a>
           </li>
+          <li class="cmp-blog__list-item">
+            <a class="cmp-blog__link" href="https://sparkbox.com/foundry/why_sparkbox_loves_typescript">
+              12. The Foundry: Why Sparkbox Loves TypeScript
+            </a>
+          </li>
         </ul>
       </div>
     </section>


### PR DESCRIPTION
## Description
<!-- Example: This PR continues to refactor the homepage with new markup and transfers styles to SCSS partials. The focus of this PR is on the cmp-contact elements. -->
This PR adds a link to the blog page to include my most recent contribution to the Foundry.

## Validation

- [ ] Pull down the branch
- [ ] Run `npm install`, then `npm start`<!-- Write additional validation if needed. -->
- [ ] [Visit the blog page](https://deploy-preview-130--marissahuysentruyt.netlify.app/blog/blog)
- [ ] Verify the "Why Sparkbox Loves Typescript" link is visible and keyboard accesssible.

<img width="508" alt="Screenshot 2025-01-01 at 12 05 09 PM" src="https://github.com/user-attachments/assets/74e1b62c-acf2-4b2f-a91e-407dd3201e70" />

- [ ] Verify the link takes you to the article on the Foundry.

<img width="1101" alt="Screenshot 2025-01-01 at 12 05 30 PM" src="https://github.com/user-attachments/assets/eccfda9c-f9d7-4feb-9edd-66f7aae9da95" />
